### PR TITLE
Add GitHub Actions workflow for Docker build and push

### DIFF
--- a/.github/workflows/docker-build-rpidaemon.yml
+++ b/.github/workflows/docker-build-rpidaemon.yml
@@ -1,0 +1,31 @@
+name: Build and Push rpiDaemon Docker Image
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and Push rpiDaemon
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./rpiDaemon/Dockerfile
+          platforms: linux/arm64
+          push: true
+          tags: aopheim/rpidaemon:latest


### PR DESCRIPTION
Automates building and pushing rpiDaemon Docker image to Docker Hub on pushes to develop branch.